### PR TITLE
Fix: several typos in word 'failed'

### DIFF
--- a/examples/kms/main.go
+++ b/examples/kms/main.go
@@ -69,13 +69,13 @@ func main() {
 
 	derEncodedPublicKey, err := x509.MarshalPKIXPublicKey(&rsaPrivateKey.PublicKey)
 	if err != nil {
-		panic(fmt.Errorf("faield to encode public key in DER format: %w", err))
+		panic(fmt.Errorf("failed to encode public key in DER format: %w", err))
 	}
 	fmt.Printf("DEREncodedPublicKey: %s\n", hexutil.Encode(derEncodedPublicKey))
 
 	attestationDoc, err := nsm.GetAttestationDoc(nil, nil, derEncodedPublicKey)
 	if err != nil {
-		panic(fmt.Errorf("faield to get attestatiokn doc: %w", err))
+		panic(fmt.Errorf("failed to get attestatiokn doc: %w", err))
 	}
 	fmt.Printf("AttestationDoc: %s\n", hexutil.Encode(attestationDoc))
 

--- a/nitro-attestation-cli/internal/document/read.go
+++ b/nitro-attestation-cli/internal/document/read.go
@@ -20,7 +20,7 @@ type ReadAttestationDocumentOptions struct {
 func ReadAttestationDocument(opts ReadAttestationDocumentOptions) error {
 	attestationDocRaw, err := os.ReadFile(opts.Input)
 	if err != nil {
-		return fmt.Errorf("faield to read input file: %w", err)
+		return fmt.Errorf("failed to read input file: %w", err)
 	}
 	attestationDoc, err := attestation.ParseNSMAttestationDoc(attestationDocRaw)
 	if err != nil {

--- a/nitro-attestation-cli/internal/kms/decrypt.go
+++ b/nitro-attestation-cli/internal/kms/decrypt.go
@@ -35,7 +35,7 @@ func Decrypt(opts DecryptOptions) error {
 	}
 	derEncodedSessionPublicKey, err := x509.MarshalPKIXPublicKey(&sessionPrivateKey.PublicKey)
 	if err != nil {
-		return fmt.Errorf("faield to marshal public key PKIX: %w", err)
+		return fmt.Errorf("failed to marshal public key PKIX: %w", err)
 	}
 	kmsAttestationDocRaw, err := nsm.GetAttestationDoc(nil, nil, derEncodedSessionPublicKey)
 	if err != nil {

--- a/nitro-attestation-cli/internal/kms/generate_data_key.go
+++ b/nitro-attestation-cli/internal/kms/generate_data_key.go
@@ -34,7 +34,7 @@ func GenerateDataKey(opts GenerateDataKeyOptions) error {
 	}
 	derEncodedSessionPublicKey, err := x509.MarshalPKIXPublicKey(&sessionPrivateKey.PublicKey)
 	if err != nil {
-		return fmt.Errorf("faield to marshal public key PKIX: %w", err)
+		return fmt.Errorf("failed to marshal public key PKIX: %w", err)
 	}
 	kmsAttestationDocRaw, err := nsm.GetAttestationDoc(nil, nil, derEncodedSessionPublicKey)
 	if err != nil {


### PR DESCRIPTION
Typos in word "faield" (correct: "failed")