### PR TITLE
Print hex string

### DIFF
--- a/nitro-attestation-cli/internal/document/read.go
+++ b/nitro-attestation-cli/internal/document/read.go
@@ -51,15 +51,15 @@ func ReadAttestationDocument(opts ReadAttestationDocumentOptions) error {
 	}
 
 	if opts.UserData {
-		fmt.Printf("%s", attestationDoc.UserData)
+		fmt.Printf("%x\n", attestationDoc.UserData)
 	}
 
 	if opts.Nonce {
-		fmt.Printf("%s", attestationDoc.UserData)
+		fmt.Printf("%x\n", attestationDoc.Nonce)
 	}
 
 	if opts.PublicKey {
-		fmt.Printf("%s", attestationDoc.UserData)
+		fmt.Printf("%x\n", attestationDoc.PublicKey)
 	}
 	return nil
 }


### PR DESCRIPTION
Change formatting from %s to %x for public key output

The public key is binary data, so using %x is more appropriate than %s.
